### PR TITLE
Allow use of `@ember/test-helpers`v4

### DIFF
--- a/addon-test-support/performance.ts
+++ b/addon-test-support/performance.ts
@@ -30,11 +30,13 @@ export function measure(comment: string, startMark: string, endMark: string) {
       performance.measure(comment, startMark, endMark);
     }
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'performance.measure could not be executed because of ',
-      e.message
-    );
+    if (e instanceof Error) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'performance.measure could not be executed because of ',
+        e.message
+      );
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "webpack": "^5.65.0"
   },
   "peerDependencies": {
-    "@ember/test-helpers": "^3.0.3",
+    "@ember/test-helpers": "^3.0.3 || ^4.0.2",
     "qunit": ">= 2"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
v4 of `@ember/test-helpers` was released lately, and appears to work just fine with `ember-a11y-testing` since the breaking changes in that release are irrelevant to this addon :)

This is basically a port of [PR #530](https://github.com/ember-a11y/ember-a11y-testing/pull/530) back to v6, enabling us to use @ember/test-helpers v4 without upgrading ember-a11y-testing to v7